### PR TITLE
Changed looking around controls to middle mouse button

### DIFF
--- a/scenes/game/singleplayer.tscn
+++ b/scenes/game/singleplayer.tscn
@@ -108,8 +108,9 @@ _move_picker = NodePath("../MovePicker")
 [node name="Custom_Camera" parent="." instance=ExtResource("7_w116q")]
 transform = Transform3D(0.848048, 0, 0.529919, 0, 1, 0, -0.529919, 0, 0.848048, 4.67672, 0.189247, 6.67064)
 max_degrees_down = 50.0
-max_degrees_left = 32.0
 _board_look_rotation = Vector3(-35, 32, 0)
+_trans_type = 1
+_ease_type = 1
 
 [node name="Prototype_UI" type="CanvasLayer" parent="."]
 follow_viewport_enabled = true

--- a/scripts/looking_around/camera_lookaround.gd
+++ b/scripts/looking_around/camera_lookaround.gd
@@ -7,6 +7,8 @@ extends Camera3D
 ## and the camera is positioned to look at the game view.
 signal on_intro_ended
 
+var _can_move_camera: bool
+
 @export var max_degrees_up: float = 35
 @export var max_degrees_down: float = 35
 @export var max_degrees_left: float = 35
@@ -14,7 +16,6 @@ signal on_intro_ended
 ## Sensitivity of the mouse in x and y. 
 ## TODO Make this a setting in the settings menu of the game in the future
 @export var _looking_sensitivity: float = 0.1
-@export var _centering_speed: float = .9
 ## Euler rotation in degrees of the fixed camera orientation used when looking at the board.
 ## The current orientation of the camera will be used as a default for the looking orientation.
 @export var _board_look_rotation := Vector3(-30, 32, 0)
@@ -33,8 +34,15 @@ var _max_rotation_x: float
 var _min_rotation_y: float
 var _max_rotation_y: float
 
+@export_category("Camera Tweening")
+@export var _trans_type: int
+@export var _ease_type: int
+@export var _tween_speed: float = 2
+@export var _intro_tween_speed: float = 0.5
+var tween_rot: Tween
+
 ## Bool indicating whether looking around is currently enabled.
-var _is_enabled = false
+var _is_looking_around = false
 ## Cached delta used for rotation in input method.
 var _delta: float
 
@@ -43,85 +51,85 @@ func _ready():
 	Input.mouse_mode = Input.MOUSE_MODE_CONFINED
 	_define_main_orientations()
 	_define_constraints()
-	
-	
+
+
 func _on_play_pressed():
-	await _return_to_board()
+	await _return_to_board(_intro_tween_speed)
 	on_intro_ended.emit()
 	_looking_border.mouse_entered.connect(_enter_looking_mode)
-	
-	
+	_can_move_camera = true
+
+
 func _process(delta):
 	# Cache the delta: time between this and previous frame.
 	_delta = delta	
 
-		
+
 func _input(event):
+	if not _can_move_camera: return
+	
 	if event is InputEventMouseButton:
 		event = event as InputEventMouseButton
-		if event.is_pressed() and event.button_index == MOUSE_BUTTON_MIDDLE:
-			_switch_mode()
+		if event.button_index == MOUSE_BUTTON_MIDDLE:
+			if event.is_pressed():
+				_is_looking_around = true
+				if tween_rot and tween_rot.is_running():
+					tween_rot.stop()
+				_switch_mode()
+			elif event.is_released():
+				_is_looking_around = false
+				_switch_mode()
 			
-	if not event is InputEventMouseMotion or not _is_enabled:
+	if not event is InputEventMouseMotion or not _is_looking_around:
 		return
 	
-	# Rotate based on mouse movement.	
+	# Rotate based on mouse movement.
 	var mouseMotionEvent = event as InputEventMouseMotion
 	var mouseDelta = mouseMotionEvent.relative as Vector2
 	rotate(Vector3.UP, _looking_sensitivity * _delta * -mouseDelta.x)		# Looking left and right
 	rotate_object_local(Vector3.RIGHT, _looking_sensitivity * _delta * -mouseDelta.y) 	# Looking up and down	
 	
-	# Constrain Rotations
+	# Constrain Rotations.
 	rotation.x = clampf(rotation.x, _min_rotation_x, _max_rotation_x)
 	rotation.y = clampf(rotation.y, _min_rotation_y, _max_rotation_y)
-	
-	var rotation_ratio = inverse_lerp(_looking_around_rotation.x, _board_look_rotation.x, rotation.x)
-	if rotation_ratio > switch_threshold_ratio:
-		_return_to_board()
-		
-		
+
+
 func _define_main_orientations():
 	_looking_around_rotation = global_rotation
 	_board_look_rotation = General.deg_to_rad(_board_look_rotation)
-	
-	
+
+
 func _define_constraints():
 	_max_rotation_x = _looking_around_rotation.x + deg_to_rad(max_degrees_up)
 	_min_rotation_x = _looking_around_rotation.x - deg_to_rad(max_degrees_down)
 	_min_rotation_y = _looking_around_rotation.y - deg_to_rad(max_degrees_right)
 	_max_rotation_y = _looking_around_rotation.y + deg_to_rad(max_degrees_left)
-		
-		
-func _switch_mode():
-	if _is_enabled:
-		_return_to_board()
-	else:
-		_enter_looking_mode()
 
-		
-func _return_to_board():
-	_is_enabled = false	
-	await _rotate_with_speed(_board_look_rotation, _centering_speed)
-	
-	Input.mouse_mode = Input.MOUSE_MODE_CONFINED	
-	#_looking_border.visible = true	
+
+func _switch_mode():
+	if _is_looking_around:
+		_enter_looking_mode()
+	else:
+		_return_to_board(_tween_speed)
+
+func _return_to_board(tween_speed: float):
+	await _rotate_with_speed(_board_look_rotation, tween_speed)
+	Input.mouse_mode = Input.MOUSE_MODE_CONFINED
 
 
 ## Triggered when hovering over the looking around border.
 func _enter_looking_mode():
-	#_looking_border.visible = false
-	await _rotate_with_speed(_looking_around_rotation, _centering_speed)
-	
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
-	_is_enabled = true
+	_is_looking_around = true
+
+
+func _rotate_with_speed(target_global_euler: Vector3, tween_speed: float):
+	var duration = target_global_euler.distance_to(global_rotation) / tween_speed
 	
-	
-func _rotate_with_speed(target_global_euler: Vector3, speed: float):
-	var duration = target_global_euler.distance_to(global_rotation) / speed
-	
-	var tween_rot = create_tween()
+	tween_rot = create_tween()
 	tween_rot.bind_node(self).set_parallel(true)
-	tween_rot.tween_property(self, "global_rotation:x", target_global_euler.x, duration)
-	tween_rot.tween_property(self, "global_rotation:y", target_global_euler.y, duration)
+	tween_rot.tween_property(self, "global_rotation:x", target_global_euler.x, duration).set_trans(_trans_type).set_ease(_ease_type)
+	tween_rot.tween_property(self, "global_rotation:y", target_global_euler.y, duration).set_trans(_trans_type).set_ease(_ease_type)
 	
 	await tween_rot.finished
+


### PR DESCRIPTION
Our previous approach felt very unintuitive to a playtester, and in hindsight that made a lot of sense. I've simplified the way looking around works: hold the middle* mouse button to start looking around with mouse movement, release it to snap back to the board.

* Should be replaced with right mouse button eventually, but with the concurrent access to that button with cancelling a move and no current mechanism to prevent overlap, the middle mouse button should work for (play)testing purposes.