### PR TITLE
Implemented Hotseat

### DIFF
--- a/scenes/game/singleplayer.tscn
+++ b/scenes/game/singleplayer.tscn
@@ -1,14 +1,13 @@
-[gd_scene load_steps=24 format=3 uid="uid://bkjl7wlfjhp01"]
+[gd_scene load_steps=23 format=3 uid="uid://bkjl7wlfjhp01"]
 
 [ext_resource type="PackedScene" uid="uid://cgkfm7n305bgj" path="res://scenes/game/environment_scaled.tscn" id="1_i3yx6"]
 [ext_resource type="Script" path="res://scripts/game/systems/game_controller.gd" id="2_ldghm"]
 [ext_resource type="PackedScene" uid="uid://s47hmmlcss14" path="res://scenes/game/entities/board.tscn" id="3_vwo4y"]
 [ext_resource type="Script" path="res://scripts/ui/prototype_ui.gd" id="5_8sxhn"]
+[ext_resource type="PackedScene" uid="uid://cr0l750ofrajc" path="res://scenes/game/systems/move_picker/move_picker_spawner.tscn" id="5_bg2we"]
 [ext_resource type="Script" path="res://scripts/ui/quit_button.gd" id="6_3dit1"]
-[ext_resource type="PackedScene" uid="uid://d3gx24dw7xjud" path="res://scenes/game/systems/move_picker/move_picker_ai.tscn" id="6_feay8"]
 [ext_resource type="PackedScene" uid="uid://bcjpac1cs0xcy" path="res://scenes/opponent_guard.tscn" id="7_tegfk"]
 [ext_resource type="PackedScene" uid="uid://c8o1oiumwk2ow" path="res://scenes/game/looking_around/lookaround_camera.tscn" id="7_w116q"]
-[ext_resource type="PackedScene" uid="uid://dqreeigpne122" path="res://scenes/game/systems/move_picker/move_picker_interactive.tscn" id="8_g3rsf"]
 [ext_resource type="PackedScene" uid="uid://d4k7dx5sp6itq" path="res://scenes/game/systems/dice_roller/dice_roller.tscn" id="9_m0jtg"]
 [ext_resource type="Script" path="res://scripts/game/components/editor/extended_marker_3d.gd" id="11_5mxbb"]
 [ext_resource type="PackedScene" uid="uid://c5i15mkikj7ia" path="res://scenes/game/systems/dice_roller/die_placing_spot.tscn" id="15_c61lh"]
@@ -127,9 +126,7 @@ transform = Transform3D(0.794096, 0, 0.607792, 0, 1, 0, -0.607792, 0, 0.794096, 
 script = ExtResource("2_ldghm")
 die_spawn_point = NodePath("../../DieSpawn")
 
-[node name="InteractiveMovePicker" parent="Systems" instance=ExtResource("8_g3rsf")]
-
-[node name="AIMovePicker" parent="Systems" instance=ExtResource("6_feay8")]
+[node name="MovePickerSpawner" parent="Systems" instance=ExtResource("5_bg2we")]
 
 [node name="DiceRoller" parent="Systems" instance=ExtResource("9_m0jtg")]
 transform = Transform3D(0.847168, 0, 0.531325, 0, 1, 0, -0.531325, 0, 0.847168, 4.6143, -0.212933, 6.44044)

--- a/scenes/game/singleplayer.tscn
+++ b/scenes/game/singleplayer.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=3 uid="uid://bkjl7wlfjhp01"]
+[gd_scene load_steps=24 format=3 uid="uid://bkjl7wlfjhp01"]
 
 [ext_resource type="PackedScene" uid="uid://cgkfm7n305bgj" path="res://scenes/game/environment_scaled.tscn" id="1_i3yx6"]
 [ext_resource type="Script" path="res://scripts/game/systems/game_controller.gd" id="2_ldghm"]
@@ -10,6 +10,7 @@
 [ext_resource type="PackedScene" uid="uid://c8o1oiumwk2ow" path="res://scenes/game/looking_around/lookaround_camera.tscn" id="7_w116q"]
 [ext_resource type="PackedScene" uid="uid://dqreeigpne122" path="res://scenes/game/systems/move_picker/move_picker_interactive.tscn" id="8_g3rsf"]
 [ext_resource type="PackedScene" uid="uid://d4k7dx5sp6itq" path="res://scenes/game/systems/dice_roller/dice_roller.tscn" id="9_m0jtg"]
+[ext_resource type="Script" path="res://scripts/game/components/editor/extended_marker_3d.gd" id="11_5mxbb"]
 [ext_resource type="PackedScene" uid="uid://c5i15mkikj7ia" path="res://scenes/game/systems/dice_roller/die_placing_spot.tscn" id="15_c61lh"]
 [ext_resource type="PackedScene" uid="uid://drllx28djyai7" path="res://scenes/npcs/npc_system.tscn" id="16_eu2sq"]
 
@@ -194,10 +195,15 @@ script = ExtResource("6_3dit1")
 [node name="Opponent_Guard_Animated" parent="." instance=ExtResource("7_tegfk")]
 transform = Transform3D(0.848048, 0, 0.52992, 0, 1, 0, -0.52992, 0, 0.848048, 4.17257, -0.684179, 5.80273)
 
-[node name="Custom_Camera" parent="." instance=ExtResource("7_w116q")]
+[node name="Custom_Camera" parent="." node_paths=PackedStringArray("_hotseat_rotation") instance=ExtResource("7_w116q")]
 transform = Transform3D(0.848048, 0, 0.529919, 0, 1, 0, -0.529919, 0, 0.848048, 4.67672, 0.189247, 6.67064)
 max_degrees_down = 50.0
 max_degrees_left = 32.0
+_hotseat_rotation = NodePath("../HotseatCameraMarker")
 _board_look_rotation = Vector3(-35, 32, 0)
+
+[node name="HotseatCameraMarker" type="Marker3D" parent="."]
+transform = Transform3D(-0.529919, -0.844821, 0.073912, 0, 0.0871554, 0.996195, -0.848048, 0.527903, -0.0461853, 4.49162, 0.111622, 6.32288)
+script = ExtResource("11_5mxbb")
 
 [node name="NPCSystem" parent="." instance=ExtResource("16_eu2sq")]

--- a/scenes/game/systems/move_picker/move_picker_spawner.tscn
+++ b/scenes/game/systems/move_picker/move_picker_spawner.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=4 format=3 uid="uid://cr0l750ofrajc"]
+
+[ext_resource type="Script" path="res://scripts/game/systems/move_picker/move_picker_spawner.gd" id="1_lal17"]
+[ext_resource type="PackedScene" uid="uid://dqreeigpne122" path="res://scenes/game/systems/move_picker/move_picker_interactive.tscn" id="2_56eq4"]
+[ext_resource type="PackedScene" uid="uid://d3gx24dw7xjud" path="res://scenes/game/systems/move_picker/move_picker_ai.tscn" id="3_eky3b"]
+
+[node name="MovePickerSpawner" type="Node"]
+script = ExtResource("1_lal17")
+move_picker_interactive = ExtResource("2_56eq4")
+move_picker_ai = ExtResource("3_eky3b")

--- a/scripts/autoloads/game_settings.gd
+++ b/scripts/autoloads/game_settings.gd
@@ -1,5 +1,6 @@
 extends Node
 
+var is_hotseat_mode: bool = true
 
 var can_stack_in_safe_spot: bool = false
 ## The number of pieces that will be used in the board game.

--- a/scripts/autoloads/game_settings.gd
+++ b/scripts/autoloads/game_settings.gd
@@ -1,6 +1,6 @@
 extends Node
 
-var is_hotseat_mode: bool = true
+var is_hotseat_mode: bool = false
 
 var can_stack_in_safe_spot: bool = false
 ## The number of pieces that will be used in the board game.

--- a/scripts/game/systems/move_picker/move_picker_spawner.gd
+++ b/scripts/game/systems/move_picker/move_picker_spawner.gd
@@ -1,0 +1,23 @@
+extends Node
+## Node that spawns MovePickers for both players, depending on playing hotseat or not.
+
+@export var move_picker_interactive: PackedScene
+@export var move_picker_ai: PackedScene
+
+func _ready():
+	GameEvents.play_pressed.connect(_spawn_move_pickers)
+	
+	
+func _spawn_move_pickers():
+	## Player 1 is always interactive move picker
+	var move_picker_p1 = move_picker_interactive.instantiate()
+	## Player 2 can be an AI or second player
+	var move_picker_p2: MovePicker
+	if Settings.is_hotseat_mode:
+		move_picker_p2 = move_picker_interactive.instantiate() as MovePicker
+	else:
+		move_picker_p2 = move_picker_ai.instantiate() as MovePicker
+	
+	add_child(move_picker_p1)
+	add_child(move_picker_p2)
+	move_picker_p2.assigned_player = General.Player.TWO

--- a/scripts/looking_around/camera_lookaround.gd
+++ b/scripts/looking_around/camera_lookaround.gd
@@ -3,11 +3,6 @@
 class_name CameraLookAround
 extends Camera3D
 
-## Sends a signal when the intro cinematic is finsihed 
-## and the camera is positioned to look at the game view.
-signal on_intro_ended
-
-
 @export var max_degrees_up: float = 35
 @export var max_degrees_down: float = 35
 @export var max_degrees_left: float = 35
@@ -17,6 +12,7 @@ signal on_intro_ended
 @export var _looking_sensitivity: float = 0.1
 ## Euler rotation in degrees of the fixed camera orientation used when looking at the board.
 ## The current orientation of the camera will be used as a default for the looking orientation.
+@export var _hotseat_rotation: Node3D
 @export var _board_look_rotation := Vector3(-30, 32, 0)
 ## When the camera nearly matches the board look rotation rather than the default looking around rotation,
 ## the camera will switch back to the fixed board camera. 
@@ -49,21 +45,28 @@ var _delta: float
 
 func _ready():
 	Input.mouse_mode = Input.MOUSE_MODE_CONFINED
-	_define_main_orientations()
-	_define_constraints()
-	GameEvents.intro_finished.connect(_on_play_pressed)
-
-
-func _on_play_pressed():
-	await _return_to_board(_intro_tween_speed)
-	on_intro_ended.emit()
-	_looking_border.mouse_entered.connect(_enter_looking_mode)
-	_can_move_camera = true
+	GameEvents.intro_finished.connect(_on_intro_finished)
+	
+	if not Settings.is_hotseat_mode:
+		_define_main_orientations()
+		_define_constraints()
 
 
 func _process(delta):
 	# Cache the delta: time between this and previous frame.
 	_delta = delta	
+	
+
+func _on_intro_finished():
+	if Settings.is_hotseat_mode:
+		global_rotation = _hotseat_rotation.global_rotation
+		global_position = _hotseat_rotation.global_position
+		set_process_input(false)
+		set_process(false)
+	else:
+		await _return_to_board(_intro_tween_speed)
+		_looking_border.mouse_entered.connect(_enter_looking_mode)
+		_can_move_camera = true
 
 
 func _input(event):
@@ -110,11 +113,12 @@ func _switch_mode():
 	else:
 		_return_to_board(_tween_speed)
 
+
 func _return_to_board(tween_speed: float):
 	await _rotate_with_speed(_board_look_rotation, tween_speed)
 	Input.mouse_mode = Input.MOUSE_MODE_CONFINED
-
-
+	
+	
 ## Triggered when hovering over the looking around border.
 func _enter_looking_mode():
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED

--- a/scripts/npc_system/npc_system.gd
+++ b/scripts/npc_system/npc_system.gd
@@ -7,6 +7,10 @@ extends Node
 var npcs: Array
 
 func _ready():
+	## Disable background NPCs when in hotseat mode
+	if Settings.is_hotseat_mode:
+		return
+	
 	npcs = get_node("NPCs").get_children()
 	
 	for npc in npcs:

--- a/scripts/opponent_npc.gd
+++ b/scripts/opponent_npc.gd
@@ -87,11 +87,12 @@ func _play_interruption(category):
 
 func _on_play_pressed():
 	visible = true
-	await _animation_player.play_walkin()
-	## Start first dialogue after a delay.
-	await get_tree().create_timer(starting_dialogue_delay).timeout
-	await _play_story_dialogue()
-	_is_timer_active = true	
+	if not Settings.is_hotseat_mode:
+		await _animation_player.play_walkin()
+		## Start first dialogue after a delay.
+		await get_tree().create_timer(starting_dialogue_delay).timeout
+		await _play_story_dialogue()
+		_is_timer_active = true	
 	GameEvents.intro_finished.emit()
 	
 	

--- a/scripts/opponent_npc.gd
+++ b/scripts/opponent_npc.gd
@@ -86,8 +86,8 @@ func _play_interruption(category):
 
 
 func _on_play_pressed():
-	visible = true
 	if not Settings.is_hotseat_mode:
+		visible = true
 		await _animation_player.play_walkin()
 		## Start first dialogue after a delay.
 		await get_tree().create_timer(starting_dialogue_delay).timeout


### PR DESCRIPTION
I implemented hotseat in a way that we can use the same scene that we use in singleplayer. 
This way, the hotseat is harder to edit, but will at least stay up to date with changes in the singleplayer gamemode.

For the movepickers, I made a small script that spawns the correct movepickers depending on the selected gamemode.