### PR TITLE
Fixed Dice Sounds Not Always Playing and Fixed Rare Dice Penetration Problem

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -84,6 +84,7 @@ ui_skip_dialogue={
 3d/sleep_threshold_linear=0.01
 3d/sleep_threshold_angular=0.01
 jolt_3d/sleep/velocity_threshold=0.001
+jolt_3d/continuous_cd/max_penetration=5.0
 
 [rendering]
 

--- a/scenes/game/environment_scaled.tscn
+++ b/scenes/game/environment_scaled.tscn
@@ -136,13 +136,6 @@ visible = false
 [node name="Table" parent="Environment" index="4"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.27508, -0.0732401, 0.195189)
 
-[node name="StaticBody3D_Table" type="StaticBody3D" parent="Environment/Table" index="0" groups=["Ground"]]
-collision_layer = 3
-collision_mask = 3
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Environment/Table/StaticBody3D_Table" groups=["Ground"]]
-transform = Transform3D(0.866025, 0, 0.5, 0, 1, 0, -0.5, 0, 0.866025, 0.871, -0.0423534, 1.379)
-shape = SubResource("BoxShape3D_080q8")
 
 [node name="TablePlank6" parent="Environment/Table" index="4" instance=ExtResource("2_mq51f")]
 transform = Transform3D(-2.18691, -1.85687e-07, -0.662298, -9.21432e-09, -2.53536, 1.97601e-07, 1.28275, -3.34781e-07, -1.12913, 1.03992, 0.0164161, 1.25593)

--- a/scenes/game/singleplayer.tscn
+++ b/scenes/game/singleplayer.tscn
@@ -16,13 +16,6 @@
 [sub_resource type="GDScript" id="GDScript_lsuqm"]
 script/source = "extends Node
 
-
-func _ready() -> void:
-	pass
-	# Settings.is_hotseat_mode = true
-	# Settings.ruleset = load(\"res://resources/rulesets/ruleset_russian_rosette.tres\")
-
-
 func _input(event: InputEvent) -> void:
 	if event is InputEventKey:
 		if event.keycode == KEY_R and event.pressed:


### PR DESCRIPTION
- The dice sounds not always playing was caused by another table collider that was still in the environment_scaled scene. This collider was not in the table group, so the sound was not played when dice collided with this collider. This collider has been removed.
- Setting the max penetration % of colliders from 25 to 5% solved the issue of dice being inside of the table collider every now and then. I assume 0% will cost more performance, so since 5 works well, we can keep it like that.