### PR TITLE
Implemented Pause Menu

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -71,6 +71,11 @@ ui_skip_dialogue={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(148, 14),"global_position":Vector2(152, 55),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
 ]
 }
+game_pause={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/scenes/game/singleplayer.tscn
+++ b/scenes/game/singleplayer.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://bksmfg8gvpyso" path="res://scenes/ui/controls_hud.tscn" id="8_wjnj8"]
 [ext_resource type="PackedScene" uid="uid://d4k7dx5sp6itq" path="res://scenes/game/systems/dice_roller/dice_roller.tscn" id="9_m0jtg"]
 [ext_resource type="PackedScene" uid="uid://cuw4r8ubsaba3" path="res://scenes/ui/main_menu.tscn" id="10_2dq8v"]
+[ext_resource type="PackedScene" uid="uid://purvwsmsb7e8" path="res://scenes/ui/pause_screen.tscn" id="10_hrgy1"]
 [ext_resource type="PackedScene" uid="uid://dwnjc775ngbs4" path="res://scenes/ui/end_screen.tscn" id="11_b3pbs"]
 [ext_resource type="AudioStream" uid="uid://cypkb6b2st6b1" path="res://audio/sfx_mastered/ambience-birds-and-crickets.mp3" id="12_6m1n2"]
 [ext_resource type="Script" path="res://scripts/audio/ambient_audio_player.gd" id="13_056ba"]
@@ -237,6 +238,8 @@ loop = false
 [node name="MainMenu" parent="." instance=ExtResource("10_2dq8v")]
 
 [node name="EndScreen" parent="." instance=ExtResource("11_b3pbs")]
+
+[node name="PauseScreen" parent="." instance=ExtResource("10_hrgy1")]
 
 [node name="AmbientAudio" type="Node3D" parent="."]
 

--- a/scenes/ui/pause_screen.tscn
+++ b/scenes/ui/pause_screen.tscn
@@ -52,7 +52,6 @@ text = "Continue"
 flat = true
 
 [node name="MainMenu" type="Button" parent="TabletPanel/Buttons"]
-visible = false
 layout_mode = 2
 theme_override_font_sizes/font_size = 50
 text = "To Main Menu"

--- a/scenes/ui/pause_screen.tscn
+++ b/scenes/ui/pause_screen.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=3 format=3 uid="uid://purvwsmsb7e8"]
+
+[ext_resource type="Script" path="res://scripts/ui/pause_screen.gd" id="1_uhldg"]
+[ext_resource type="Theme" uid="uid://w7yb2efymxa0" path="res://UI/main_theme.tres" id="2_mw35u"]
+
+[node name="PauseScreen" type="CanvasLayer"]
+script = ExtResource("1_uhldg")
+
+[node name="TabletPanel" type="Panel" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -350.0
+offset_top = -500.0
+offset_right = 350.0
+offset_bottom = 500.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HeaderLabel" type="Label" parent="TabletPanel"]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -291.0
+offset_top = 40.0
+offset_right = 304.0
+offset_bottom = 122.0
+grow_horizontal = 2
+theme = ExtResource("2_mw35u")
+theme_override_font_sizes/font_size = 64
+text = "Game Paused"
+horizontal_alignment = 1
+
+[node name="Buttons" type="VBoxContainer" parent="TabletPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 50
+alignment = 1
+metadata/_edit_group_ = true
+
+[node name="Continue" type="Button" parent="TabletPanel/Buttons"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+text = "Continue"
+flat = true
+
+[node name="MainMenu" type="Button" parent="TabletPanel/Buttons"]
+visible = false
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+text = "To Main Menu"
+flat = true
+
+[node name="Quit" type="Button" parent="TabletPanel/Buttons"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+text = "Quit
+"
+flat = true
+
+[connection signal="pressed" from="TabletPanel/Buttons/Continue" to="." method="_on_continue_pressed"]
+[connection signal="pressed" from="TabletPanel/Buttons/MainMenu" to="." method="_on_main_menu_pressed"]
+[connection signal="pressed" from="TabletPanel/Buttons/Quit" to="." method="_on_quit_pressed"]

--- a/scripts/autoloads/game_manager.gd
+++ b/scripts/autoloads/game_manager.gd
@@ -11,9 +11,21 @@ var fast_move_enabled := false
 var ruleset
 var game_aborted_flag
 
+## Opponent dialogue flags
+var opponent_explained_rosettes_extra_roll: bool
+var opponent_explained_rosettes_are_safe: bool
+var opponent_explained_capturing: bool
+var opponent_explained_securing: bool
+var opponent_explained_everything: bool
+
+
+func _ready():
+	GameEvents.back_to_main_menu_pressed.connect(_on_back_to_main_menu)
+
 
 func start_new_game() -> void:
 	_setup_board()
+	game_aborted_flag = false
 	
 	if not is_hotseat:
 		await GameEvents.opponent_ready
@@ -23,11 +35,11 @@ func start_new_game() -> void:
 		turn_number = 0
 		GameEvents.game_started.emit()
 		GameEvents.new_turn_started.emit()
-		game_aborted_flag = false
 	
 	
-func on_back_to_main_menu():
+func _on_back_to_main_menu():
 	game_aborted_flag = true
+	## Force the await in start_new_game() to stop
 	GameEvents.opponent_ready.emit()
 
 

--- a/scripts/autoloads/game_manager.gd
+++ b/scripts/autoloads/game_manager.gd
@@ -8,7 +8,8 @@ var is_rematch := false
 var is_hotseat := false
 var fast_move_enabled := false
 
-var ruleset: Ruleset
+var ruleset
+var game_aborted_flag
 
 
 func start_new_game() -> void:
@@ -17,10 +18,17 @@ func start_new_game() -> void:
 	if not is_hotseat:
 		await GameEvents.opponent_ready
 	
-	current_player = General.get_random_player()
-	turn_number = 0
-	GameEvents.game_started.emit()
-	GameEvents.new_turn_started.emit()
+	if not game_aborted_flag:
+		current_player = General.get_random_player()
+		turn_number = 0
+		GameEvents.game_started.emit()
+		GameEvents.new_turn_started.emit()
+		game_aborted_flag = false
+	
+	
+func on_back_to_main_menu():
+	game_aborted_flag = true
+	GameEvents.opponent_ready.emit()
 
 
 func _setup_board():

--- a/scripts/dialogue_system/logic/dialogue_group_player_base.gd
+++ b/scripts/dialogue_system/logic/dialogue_group_player_base.gd
@@ -42,11 +42,9 @@ func check_priority(new_group: DialogueGroup):
 
 
 func is_busy():
-	## TODO: Double-check
 	return _sequence_player.is_playing
 
 
 ## Virtual method
 func _pick_sequence(group: DialogueGroup) -> DialogueSequence:
 	return null
-

--- a/scripts/dialogue_system/logic/dialogue_inorder_player.gd
+++ b/scripts/dialogue_system/logic/dialogue_inorder_player.gd
@@ -5,9 +5,6 @@ extends DialogueGroupPlayerBase
 @export var _supports_interruptions: bool
 @export var _temp_interruption: DialogueGroup 
 
-## TODO: IDK
-#@onready var _interruption_player = $InterruptionPlayer as DialogueGroupPlayerBase
-
 var _current_dialogues: Array[DialogueSequence]
 var _current_index = -1
 
@@ -33,22 +30,3 @@ func has_next():
 func reset():
 	_current_index = -1
 	_current_dialogues = []
-	
-	
-## TODO: Idk how to handle interruptions yet.
-#func interrupt():
-	#if not _supports_interruptions:
-		#push_warning("DialogueCollectionPlayer.interrupt(): This dialogue system does not support interruptions")
-	#
-	### TODO: For the prototype this is fine, but we might reconsider this later.
-	### I put a todo just to not forget this part.
-	#if _interruption_player.is_playing:
-		#return
-	#
-	#if _sequence_player.is_playing:
-		#_sequence_player.interrupt()
-		#await _sequence_player.on_interruption_ready
-	#await _interruption_player.play(_temp_interruption)
-	#_sequence_player.continue_dialogue()
-
-

--- a/scripts/dialogue_system/logic/dialogue_sequence_player.gd
+++ b/scripts/dialogue_system/logic/dialogue_sequence_player.gd
@@ -112,6 +112,12 @@ func _handle_opponent_action_prevention(entry: DialogueBundle):
 		GameEvents.opponent_action_resumed.emit()
 
 
+func stop():
+	_audio_player.stop()
+	_animation_player.stop()
+	_subtitle_displayer.hide_subtitles() 
+
+
 func handle_interruption():
 	if _use_subtitles:
 		_subtitle_displayer.hide_subtitles()

--- a/scripts/dialogue_system/logic/dialogue_system.gd
+++ b/scripts/dialogue_system/logic/dialogue_system.gd
@@ -70,6 +70,11 @@ func play(category: Category) -> bool:
 	return false
 	
 	
+func stop():
+	_dialogue_sequence_player.stop()
+	_interruption_sequence_player.stop()
+	
+	
 func set_animation_player(animation_player: AnimationPlayer):
 	_animation_player = animation_player
 	_dialogue_sequence_player.set_animation_player(animation_player)

--- a/scripts/dialogue_system/logic/dialogue_system.gd
+++ b/scripts/dialogue_system/logic/dialogue_system.gd
@@ -37,15 +37,20 @@ var _animation_player: AnimationPlayer
 
 
 func _ready():
-	_player_inorder.assign_sequence_player(_dialogue_sequence_player, _interruption_sequence_player)
-	_player_random.assign_sequence_player(_dialogue_sequence_player, _interruption_sequence_player)
-	GameEvents.subtitle_panel_clicked.connect(continue_dialogue)
-	
-	
+    _player_inorder.assign_sequence_player(_dialogue_sequence_player, _interruption_sequence_player)
+    _player_random.assign_sequence_player(_dialogue_sequence_player, _interruption_sequence_player)
+    GameEvents.subtitle_panel_clicked.connect(continue_dialogue)
+    GameEvents.play_pressed.connect(_on_play_pressed)
+    
+    
 func _input(event):
-	if event.is_action_pressed("skip_dialogue"):
-		continue_dialogue()
-
+    if event.is_action_pressed("skip_dialogue"):
+        continue_dialogue()
+    
+        
+func _on_play_pressed():
+    reset()
+    
 
 func continue_dialogue():
 	if _interruption_sequence_player.is_busy():
@@ -56,20 +61,28 @@ func continue_dialogue():
 
 ## Tries to play a DialogueSequence in the correct category. Returns whether the operation was successfull.
 func play(category: Category) -> bool:
-	if is_busy() and _interruption_sequence_player.is_busy():
-		return false
-		
-	for group in _dialogue_groups:
-		if group.category == category:
-			var group_player = _player_inorder if group.play_in_order else _player_random
-			_current_dialogue_player = group_player
-			var success = await group_player.play_sequence_from_group(group)
-			_current_dialogue_player = null
-			return success
-			
-	return false
-	
-	
+    if is_busy() and _interruption_sequence_player.is_busy():
+        return false
+        
+    for group in _dialogue_groups:
+        if group.category == category:
+            var group_player = _player_inorder if group.play_in_order else _player_random
+            _current_dialogue_player = group_player
+            var success = await group_player.play_sequence_from_group(group)
+            _current_dialogue_player = null
+            return success
+            
+    return false
+    
+
+func reset():
+    stop()
+    _player_inorder.reset()
+    for group: DialogueGroup in _dialogue_groups:
+        for sequence in group.dialogue_sequences:
+            sequence.was_played = false
+    
+
 func stop():
 	_dialogue_sequence_player.stop()
 	_interruption_sequence_player.stop()

--- a/scripts/game/game_camera.gd
+++ b/scripts/game/game_camera.gd
@@ -104,6 +104,9 @@ func _update_look_around(mouse_delta: Vector2) -> void:
 
 
 func _on_play_pressed() -> void:
+	if GameManager.is_rematch:
+		return
+	
 	var target_pov: Node3D
 	if GameManager.is_hotseat:
 		target_pov = pov_hotseat

--- a/scripts/game/systems/dice_roller.gd
+++ b/scripts/game/systems/dice_roller.gd
@@ -43,8 +43,7 @@ func _on_new_turn_started() -> void:
 	if GameManager.current_player != assigned_player:
 		return
 	
-	if GameManager.is_bot_playing():
-		automatic = true
+	automatic = GameManager.is_bot_playing()
 	
 	_dehighlight_dice()
 	await _place_dice()

--- a/scripts/game/systems/move_picker/game_move_highlight.gd
+++ b/scripts/game/systems/move_picker/game_move_highlight.gd
@@ -66,6 +66,9 @@ func highlight(move: GameMove, base_color := color_neutral) -> void:
 
 
 func clear_highlight(move: GameMove) -> void:
+	if not move.from or not move.to:
+		return
+	
 	move.from.highlight.set_active(false)
 	move.to.highlight.set_active(false)
 	for piece in move.pieces_in_from:

--- a/scripts/game/systems/move_picker/game_move_selector_ai.gd
+++ b/scripts/game/systems/move_picker/game_move_selector_ai.gd
@@ -49,6 +49,7 @@ const BASE_SHARED_SPOT_DANGER_SCORE: float = 0.1
 @export_range(0.1, 5.0) var move_highlight_duration: float = 1.0
 
 var _is_busy_talking: bool
+var _game_aborted_flag: bool
 
 
 func _ready():
@@ -136,6 +137,9 @@ func _calculate_base_score(move: GameMove):
 
 #region ScoreModifiers
 func _calculate_safety_modifier(move: GameMove):
+	if _game_aborted_flag:
+		return -1
+	
 	var opponent = General.get_opponent(move.player)
 	var from_danger_score = _calculate_danger_score(move.from, move.is_from_safe, opponent)
 	var to_danger_score = _calculate_danger_score(move.to, move.is_to_safe, opponent)
@@ -166,11 +170,17 @@ func _calculate_danger_score(spot: Spot, spot_safe: bool, opponent: int) -> floa
 
 
 func _calculate_progress_modifier(move: GameMove):
+	if _game_aborted_flag:
+		return -1
+	
 	var progression = move.from_track_pos
 	return piece_progress_score_weight * progression 
 	
 	
 func _calculate_central_rosette_modifier(move: GameMove):
+	if _game_aborted_flag:
+		return -1
+	
 	var is_current_spot_central_rosette = move.is_from_shared and move.is_from_safe
 	var is_landing_spot_central_rosette = move.is_to_shared and move.is_to_safe
 	
@@ -195,6 +205,9 @@ func _calculate_central_rosette_modifier(move: GameMove):
 
 
 func _get_num_opponent_pieces_ahead(move: GameMove) -> int:
+	if _game_aborted_flag:
+		return -1
+	
 	var board = EntityManager.get_board()
 	var from_index = board.get_track(move.player).find(move.from)
 	

--- a/scripts/game/systems/move_picker/game_move_selector_interactive.gd
+++ b/scripts/game/systems/move_picker/game_move_selector_interactive.gd
@@ -119,7 +119,7 @@ func _on_to_selected(selected_move: GameMove) -> void:
 
 
 func _clear_connections(move: GameMove) -> void:
-	if move.from.input == null:
+	if not move.from or not move.to:
 		return
 	
 	if move.from.input.hovered.is_connected(_on_from_hovered.bind(move.from)):

--- a/scripts/game/systems/move_picker/game_move_selector_interactive.gd
+++ b/scripts/game/systems/move_picker/game_move_selector_interactive.gd
@@ -119,6 +119,9 @@ func _on_to_selected(selected_move: GameMove) -> void:
 
 
 func _clear_connections(move: GameMove) -> void:
+	if move.from.input == null:
+		return
+	
 	if move.from.input.hovered.is_connected(_on_from_hovered.bind(move.from)):
 		move.from.input.hovered.disconnect(_on_from_hovered.bind(move.from))
 	if move.from.input.dehovered.is_connected(_on_from_dehovered.bind(move.from)):

--- a/scripts/game/systems/move_picker/move_picker.gd
+++ b/scripts/game/systems/move_picker/move_picker.gd
@@ -19,6 +19,7 @@ func _ready() -> void:
 	GameEvents.rolled.connect(_on_dice_rolled)
 	GameEvents.roll_sequence_finished.connect(_on_roll_sequence_finished)
 	GameEvents.game_ended.connect(_on_game_ended)
+	GameEvents.back_to_main_menu_pressed.connect(_on_game_ended)
 
 
 func _on_dice_rolled(value: int) -> void:

--- a/scripts/game/systems/move_picker/piece_dragger.gd
+++ b/scripts/game/systems/move_picker/piece_dragger.gd
@@ -16,6 +16,7 @@ func _ready() -> void:
 	selector.from_spot_selected.connect(_on_from_spot_selected)
 	selector.selection_canceled.connect(_on_selection_cancel)
 	selector.move_selected.connect(_on_move_selected.unbind(1))
+	GameEvents.back_to_main_menu_pressed.connect(_on_selection_cancel)
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/scripts/npc_system/behavior_tree/action_nodes/animation_task.gd
+++ b/scripts/npc_system/behavior_tree/action_nodes/animation_task.gd
@@ -8,7 +8,7 @@ var _init_delay: float
 var _status
 
 
-func _init(anim_name: String, wait_until_anim_end: bool = false, custom_blend = 0.2, init_delay = 0):
+func _init(anim_name: String, wait_until_anim_end: bool = false, custom_blend: float  = 0.2, init_delay: float = 0):
 	_anim_name = anim_name
 	_wait_until_anim_end = wait_until_anim_end
 	_custom_blend = custom_blend

--- a/scripts/ui/controls_hud.gd
+++ b/scripts/ui/controls_hud.gd
@@ -14,6 +14,7 @@ func _ready():
 	
 	GameEvents.game_started.connect(_on_game_started)
 	GameEvents.game_ended.connect(_on_game_ended)
+	GameEvents.back_to_main_menu_pressed.connect(_on_game_ended)
 	GameEvents.drag_move_start.connect(_on_drag_move_started)
 	GameEvents.drag_move_stopped.connect(_on_drag_move_stopped)
 	GameEvents.new_turn_started.connect(_on_new_turn_started)

--- a/scripts/ui/end_screen.gd
+++ b/scripts/ui/end_screen.gd
@@ -38,8 +38,8 @@ func _on_game_ended() -> void:
 
 func _on_rematch_button_pressed() -> void:
 	visible = false
-	GameEvents.play_pressed.emit()
 	GameManager.is_rematch = true
+	GameEvents.play_pressed.emit()
 	GameManager.start_new_game()
 
 

--- a/scripts/ui/pause_screen.gd
+++ b/scripts/ui/pause_screen.gd
@@ -3,46 +3,22 @@ extends CanvasLayer
 ## Signal that fires when we can safely return to the menu.
 signal on_can_return_safely
 
-var can_return_safely: bool
 var is_paused := false
 ## Pausing is only allowed during the game, not when other menus are open.
 var can_pause := false
 
 func _ready():
 	visible = false
-	GameEvents.play_pressed.connect(_on_play_pressed)
+	GameEvents.game_started.connect(_on_game_started)
 	GameEvents.game_ended.connect(_on_game_ended)
 	
 	
-func _on_play_pressed():
+func _on_game_started():
 	can_pause = true
-	can_return_safely = true
-	
-	#GameEvents.move_executed.connect(_on_phase_ended)
-	#GameEvents.rolled.connect(_on_phase_ended)
-	#GameEvents.opponent_action_prevented.connect(_on_phase_ended)
-	#GameEvents.new_turn_started.connect(_on_danger_started)
-	#GameEvents.roll_sequence_finished.connect(_on_danger_started)
-	#GameEvents.intro_sequence_finished.connect(_on_danger_started)
-	#GameEvents.opponent_action_resumed.connect(_on_phase_ended)	
 	
 	
 func _on_game_ended():
 	can_pause = false
-	#if GameEvents.move_executed.is_connected(_on_phase_ended):
-		#GameEvents.move_executed.disconnect(_on_phase_ended)
-	#if GameEvents.roll_sequence_finished.is_connected(_on_phase_ended):
-		#GameEvents.roll_sequence_finished.disconnect(_on_phase_ended)
-	
-	
-### Triggered when a player just finished a roll or move.
-#func _on_phase_ended():
-	#can_return_safely = true
-	#on_can_return_safely.emit()
-	#
-	#
-#func _on_danger_started():
-	#can_return_safely = false
 	
 
 func _input(event):
@@ -64,11 +40,9 @@ func _on_continue_pressed():
 
 func _on_main_menu_pressed():
 	toggle_pause()
-	if not can_return_safely:
-		await on_can_return_safely
 	_on_game_ended()
 	GameEvents.back_to_main_menu_pressed.emit()
-
+	get_tree().reload_current_scene()
 
 func _on_quit_pressed():
 	get_tree().quit()

--- a/scripts/ui/pause_screen.gd
+++ b/scripts/ui/pause_screen.gd
@@ -1,13 +1,52 @@
 extends CanvasLayer
 
+## Signal that fires when we can safely return to the menu.
+signal on_can_return_safely
+
+var can_return_safely: bool
 var is_paused := false
+## Pausing is only allowed during the game, not when other menus are open.
+var can_pause := false
 
 func _ready():
 	visible = false
+	GameEvents.play_pressed.connect(_on_play_pressed)
+	GameEvents.game_ended.connect(_on_game_ended)
+	
+	
+func _on_play_pressed():
+	can_pause = true
+	can_return_safely = true
+	
+	#GameEvents.move_executed.connect(_on_phase_ended)
+	#GameEvents.rolled.connect(_on_phase_ended)
+	#GameEvents.opponent_action_prevented.connect(_on_phase_ended)
+	#GameEvents.new_turn_started.connect(_on_danger_started)
+	#GameEvents.roll_sequence_finished.connect(_on_danger_started)
+	#GameEvents.intro_sequence_finished.connect(_on_danger_started)
+	#GameEvents.opponent_action_resumed.connect(_on_phase_ended)	
+	
+	
+func _on_game_ended():
+	can_pause = false
+	#if GameEvents.move_executed.is_connected(_on_phase_ended):
+		#GameEvents.move_executed.disconnect(_on_phase_ended)
+	#if GameEvents.roll_sequence_finished.is_connected(_on_phase_ended):
+		#GameEvents.roll_sequence_finished.disconnect(_on_phase_ended)
+	
+	
+### Triggered when a player just finished a roll or move.
+#func _on_phase_ended():
+	#can_return_safely = true
+	#on_can_return_safely.emit()
+	#
+	#
+#func _on_danger_started():
+	#can_return_safely = false
 	
 
 func _input(event):
-	if event is InputEventKey and event.is_action_pressed("game_pause"):
+	if can_pause and event is InputEventKey and event.is_action_pressed("game_pause"):
 		toggle_pause()
 
 
@@ -24,7 +63,10 @@ func _on_continue_pressed():
 
 
 func _on_main_menu_pressed():
-	toggle_pause()	
+	toggle_pause()
+	if not can_return_safely:
+		await on_can_return_safely
+	_on_game_ended()
 	GameEvents.back_to_main_menu_pressed.emit()
 
 

--- a/scripts/ui/pause_screen.gd
+++ b/scripts/ui/pause_screen.gd
@@ -1,0 +1,32 @@
+extends CanvasLayer
+
+var is_paused := false
+
+func _ready():
+	visible = false
+	
+
+func _input(event):
+	if event is InputEventKey and event.is_action_pressed("game_pause"):
+		toggle_pause()
+
+
+func toggle_pause():
+	is_paused = not is_paused
+	Engine.time_scale = 0 if is_paused else 1
+	visible = is_paused
+
+
+func _on_continue_pressed():
+	## Unless we already press the game pause button at the exact same frame, unpause the menu.
+	if not Input.is_action_just_pressed("game_pause"):
+		toggle_pause()
+
+
+func _on_main_menu_pressed():
+	toggle_pause()	
+	GameEvents.back_to_main_menu_pressed.emit()
+
+
+func _on_quit_pressed():
+	get_tree().quit()

--- a/scripts/ui/pause_screen.gd
+++ b/scripts/ui/pause_screen.gd
@@ -1,7 +1,7 @@
 extends CanvasLayer
 
 ## Signal that fires when we can safely return to the menu.
-signal on_can_return_safely
+signal reload_scene
 
 var is_paused := false
 ## Pausing is only allowed during the game, not when other menus are open.
@@ -9,11 +9,11 @@ var can_pause := false
 
 func _ready():
 	visible = false
-	GameEvents.game_started.connect(_on_game_started)
+	GameEvents.play_pressed.connect(_on_play_pressed)
 	GameEvents.game_ended.connect(_on_game_ended)
 	
 	
-func _on_game_started():
+func _on_play_pressed():
 	can_pause = true
 	
 	
@@ -42,7 +42,10 @@ func _on_main_menu_pressed():
 	toggle_pause()
 	_on_game_ended()
 	GameEvents.back_to_main_menu_pressed.emit()
+	## TODO: Remove when this signal is connected.
 	get_tree().reload_current_scene()
+	reload_scene.emit()
+
 
 func _on_quit_pressed():
 	get_tree().quit()


### PR DESCRIPTION
This branch has quite some changes and bugfixes, but I was also very cooked while making this branch so there might still be some trash in there.

Bugfixes:
- Fixed Diceroller still being automatic if player enters singleplayer first and then plays hotseat.
- Fixed rematching logic for the opponent not working.

Returning to main menu:
- For the end screen, I fixed some minor scenarios where the resetting would still break, but i DO NOT reload here. Since the transition looks quite nice and I have not encountered any other bugs with it so far, I think it would be nice to leave it as is.
- The pause menu however DOES reload the scene. I actually think this transition does not look weird or off, since the player actively decides to cancel their game. We could still try together to make sure that reloading is not needed if you really want, but lets maybe merge this version that is finally working first haha